### PR TITLE
Added option to disable public list of payments.

### DIFF
--- a/Addon Module/modules/addons/group_pay/group_pay.php
+++ b/Addon Module/modules/addons/group_pay/group_pay.php
@@ -20,6 +20,7 @@ function group_pay_config() {
 		//'LicenseKey' => array("FriendlyName" => "LicenseKey", "Type" => "text", "Size"=>"10",),
 		'MinPayment' => array("FriendlyName" => "Minimum Payment ($)", "Type" => "text", "Size"=>"10"),
 		'PageIcon' => array("FriendlyName" => "Page Icon", "Type" => "text", "Size"=>"30"),
+		'HidePublicPayments' => array ("FriendlyName" => "Disable Public List of Payments", "Type" => "yesno"),
 		)
 	);
 

--- a/Front End Files/grouppay.php
+++ b/Front End Files/grouppay.php
@@ -70,6 +70,7 @@ while($pastPayment = mysql_fetch_array($dbPastPayments)){
 
 $smartyvalues['pastPayments'] = $pastPayments;
 $smartyvalues["grouppayActive"] = ($gpSettings['Enabled'] == "on"); 
+$smartyvalues["hidePublicPayments"] = ($gpSettings['HidePublicPayments'] == "on");
 $smartyvalues["SystemName"] = $gpSettings['SystemName'];
 $smartyvalues["fromPaypal"] = $fromPaypal;	
 $smartyvalues["minPayment"] = $gpSettings['MinPayment'];

--- a/Templates/grouppay.tpl
+++ b/Templates/grouppay.tpl
@@ -17,7 +17,7 @@
 			{* DELETE THE BELOW CODE TO REMOVE PAST PAYMENTS SHOWING FOR LOGGED IN CLIENTS *}
 			
 				<h2>Past {$SystemName} Payments</h2>
-				<p>Below are a list of past payments which have been made.</p>
+				<p>Below are a list of past payments which have been made.{if $hidePublicPayments} These are not shown to the public.{/if}</p>
 				<table class="data" style="width:100%">
 					<tr><th>Date</th><th>Paid By</th><th>Amount</th></tr>
 					{foreach from=$pastPayments key=myId item=pmnt}
@@ -38,7 +38,7 @@
 				<b>Payment Amount:</b> <input type=textbox name="amount"/><br>		
 				{* REQUIRED *} {$gpFormEnd} {* REQUIRED *}
 				
-				{* DELETE THE BELOW CODE TO REMOVE PAST PAYMENTS SHOWING FOR PEOPLE MAKING PAYMENTS *}
+				{if ! $hidePublicPayments}
 			
 					<h2>Past {$SystemName} Payments</h2>
 					<p>Below are a list of past payments which have been made.</p>
@@ -49,8 +49,8 @@
 						{/foreach}
 					</table>
 				
-				{* DELETE THE ABOVE CODE TO REMOVE PAST PAYMENTS SHOWING FOR PEOPLE MAKING PAYMENTS *}
-				
+				{/if}
+
 			{else}
 				{* Payer Has Provided an invalid hash *}
 				You have provided a bad client hash.<br>


### PR DESCRIPTION
I think this should be an option so that companies don't need to erase a chunk out of the template (perhaps they want to just use the stock files, or maybe they don't know to edit the file) when they don't want emails available for crawlers to see.

I can see why you might prefer it as a template-only thing though, feel free to decline if you disagree with the bit of overhead/complexity that this might add.
